### PR TITLE
Added MemcardRex plugin interface

### DIFF
--- a/ChocoEdit/ChocoEdit.csproj
+++ b/ChocoEdit/ChocoEdit.csproj
@@ -5,7 +5,7 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Library</OutputType>
     <RootNamespace>ChocoEdit</RootNamespace>
     <AssemblyName>ChocoEdit</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
@@ -38,6 +38,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
@@ -58,10 +61,13 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MainForm.cs" />
+    <Compile Include="MainForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Plugin.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SAV\Choco.cs" />

--- a/ChocoEdit/ChocoEdit.csproj
+++ b/ChocoEdit/ChocoEdit.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <ProjectGuid>{41ABAC38-D34B-489D-A450-3E9FADD07419}</ProjectGuid>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -8,8 +8,9 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>ChocoEdit</RootNamespace>
     <AssemblyName>ChocoEdit</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -29,6 +30,13 @@
     <Optimize>True</Optimize>
     <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
     <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <Prefer32Bit>false</Prefer32Bit>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp">
@@ -62,9 +70,7 @@
   <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="SAV" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>

--- a/ChocoEdit/MainForm.cs
+++ b/ChocoEdit/MainForm.cs
@@ -22,362 +22,395 @@ using System.Diagnostics;
 
 namespace ChocoEdit
 {
-	/// <summary>
-	/// Description of MainForm.
-	/// </summary>
-	public partial class MainForm : Form
-	{
+    /// <summary>
+    /// Description of MainForm.
+    /// </summary>
+    public partial class MainForm : Form
+    {
 
-		public MainForm()
-		{
-			AppDomain.CurrentDomain.ProcessExit += new EventHandler (OnProcessExit); 
-			//
-			// The InitializeComponent() call is required for Windows Forms designer support.
-			//
-			InitializeComponent();
-			
-			string tempExeName = Path.Combine(Directory.GetCurrentDirectory(), "lzs.exe");
-			
-			ResourceManager resources = new ResourceManager("ChocoEdit.MainForm", Assembly.GetExecutingAssembly());
-			byte[] exeData = (byte[])resources.GetObject("lzs");
-			using(FileStream fsDst = new FileStream(tempExeName,FileMode.Create,FileAccess.Write))
-			{
-				fsDst.Write(exeData, 0, exeData.Length);
-			}   
-			
-			//
-			// TODO: Add constructor code after the InitializeComponent() call.
-			//
-		}
-		public string loadfilter = "PSXGameEdit single save or Chocorpg PC file|*.mcs;CHOCORPG;*.ff8|All Files (*.*)|*.*";
-		public string mcsfilter = "PSXGameEdit single save|*.mcs|All Files (*.*)|*.*";
-		public string chocorpgfilter = "CHOCORPG FF8 PC save file|CHOCORPG;*.ff8|All Files (*.*)|*.*";
-		public byte[] savebuffer;
-		public byte[] ff8buffer;
-		public UInt32 ff8ID;
-		public static Choco save;
+        public MainForm(bool pluginEdit)
+        {
+            AppDomain.CurrentDomain.ProcessExit += new EventHandler(OnProcessExit);
+            //
+            // The InitializeComponent() call is required for Windows Forms designer support.
+            //
+            InitializeComponent();
+            pluginEditing = pluginEdit;
 
-		void MainScreenDragEnter(object sender, DragEventArgs e)
-		{
-			e.Effect = DragDropEffects.All;
-		}
-		void MainScreenDragDrop(object sender, DragEventArgs e)
-		{
-			string[] files = (string[])e.Data.GetData(DataFormats.FileDrop, false);
-			load_savegame(files[0]);
-		}
-		void Loadsave_butClick(object sender, EventArgs e)
-		{
-			load_savegame(null);
-		}
-		public static int compressor = 0;//0 lzs.exe, 1 qt-lzs.exe and unlzs.exe
-		public static string pathTempfile = null;
-		public static bool isCompressed = true;
-		void load_savegame(string filepath)
-		{
-			
-			string path = filepath;
-			int filesize = FileIO.load_file(ref savebuffer, ref path, loadfilter);
-			versiontext.Text = "";
+            //No need for lsz in psx plugin edit mode
+            if (pluginEdit)
+            {
+                this.StartPosition = FormStartPosition.CenterParent;
+                return;
+            }
 
-			if( filesize > 0 )
-			{
-				savegamename.Text = path;
-				save = new Choco(savebuffer, filesize);
-				
-				if (filesize == Choco.PSXSIZE) //PSX
-				{
-					versiontext.Text = "PSX";
-					save_but.Enabled = true;
-					ff8id_set.Enabled = true;
-					
-					load_data();
-				}
-				else //PC
-				{
-					//Decompress if needed
-					if(save.isLzs == true)
-					{
-						isCompressed = true;
-						versiontext.Text = "PC";
-						string pathLZS;
-						
-						if (compressor == 0)//use lzs.exe
-						{
-					
-							pathLZS = Path.Combine(Directory.GetCurrentDirectory(),"lzs.exe");
-							pathTempfile = Path.Combine(Directory.GetCurrentDirectory(),"tempfile.ff8");
-							
-							//Cleanup so we don't load a previous savefile if some error occurs
-							if (File.Exists(pathTempfile)) File.Delete(pathTempfile);
-							
-							//Decompress
-							ProcessStartInfo startLZS = new ProcessStartInfo(pathLZS);
-							startLZS.WindowStyle = ProcessWindowStyle.Hidden;
-							
-							startLZS.Arguments = "-d \""+path+"\" \""+pathTempfile+"\"";
-							var process = Process.Start(startLZS);
-							process.WaitForExit();
-							//
-							path = Path.Combine(Directory.GetCurrentDirectory(),"tempfile.ff8");
-						}
-						else if (compressor == 1)//Use qt-lzs
-						{
-							//If we are loading a new compressed file, delete previous decompressed one
-							if (pathTempfile != null)
-								if (File.Exists(pathTempfile)) File.Delete(pathTempfile);
-							
-							pathLZS = "\"" + Path.Combine(Directory.GetCurrentDirectory(), "qt-lzs\\unlzs.exe") + "\"";
-							pathTempfile = Path.Combine(Path.Combine(Directory.GetCurrentDirectory(), "qt-lzs"), Path.GetFileName(path) + ".dec");
+            string tempExeName = Path.Combine(Directory.GetCurrentDirectory(), "lzs.exe");
 
-							//Cleanup so we don't load a previous decomp savefile if some error occurs
-							if (File.Exists(pathTempfile)) File.Delete(pathTempfile);
-							
-							//Decompress
-							ProcessStartInfo startLZS = new ProcessStartInfo(pathLZS);
-							startLZS.WindowStyle = ProcessWindowStyle.Hidden;
-							
-							startLZS.Arguments = "\""+path+"\" "+"\""+Path.Combine(Directory.GetCurrentDirectory(),"qt-lzs")+"\"";
-							var process = Process.Start(startLZS);
-							process.WaitForExit();
-							//
-							
-							path = pathTempfile;
-						}
-					}
-					else
-					{
-						isCompressed = false;
-						versiontext.Text = "PC (uncompressed)";
-					}
+            ResourceManager resources = new ResourceManager("ChocoEdit.MainForm", Assembly.GetExecutingAssembly());
+            byte[] exeData = (byte[])resources.GetObject("lzs");
+            using (FileStream fsDst = new FileStream(tempExeName, FileMode.Create, FileAccess.Write))
+            {
+                fsDst.Write(exeData, 0, exeData.Length);
+            }
 
-					FileIO.load_file(ref savebuffer, ref path, null);
+            //
+            // TODO: Add constructor code after the InitializeComponent() call.
+            //
+        }
+        public string loadfilter = "PSXGameEdit single save or Chocorpg PC file|*.mcs;CHOCORPG;*.ff8|All Files (*.*)|*.*";
+        public string mcsfilter = "PSXGameEdit single save|*.mcs|All Files (*.*)|*.*";
+        public string chocorpgfilter = "CHOCORPG FF8 PC save file|CHOCORPG;*.ff8|All Files (*.*)|*.*";
+        public byte[] savebuffer;
+        public byte[] ff8buffer;
+        public UInt32 ff8ID;
+        public static Choco save;
 
-					save = new Choco(savebuffer);
-					save_but.Enabled = true;
-					load_data();
-					//Remove *.dec file
-					if (File.Exists(path)) File.Delete(path);
-				}
-				
-			}
-			else
-			{
-				MessageBox.Show("Invalid file.");
-				savegamename.Text = "";
-				save_but.Enabled = false;
-				ff8id_set.Enabled = false;
-			}
-		}
-		void Save_butClick(object sender, EventArgs e)
-		{
-			save_data();
-			if (save.Data.Length == Choco.PSXSIZE)
-			{
-				FileIO.save_file(save.Data, mcsfilter);
-			}
-			else
-			{
-				string pathLZS;
-				string pathTempfile2;
-				string path;
-				if (isCompressed == true) //Recompress
-				{
-					if (compressor == 0) //lzs.exe
-					{
-						//Write edited data to temp file we will be compressing
-						FileIO.write_file(save.Data, Path.Combine(Directory.GetCurrentDirectory(),"tempfile.ff8"));
-						
-						pathLZS = Path.Combine(Directory.GetCurrentDirectory(),"lzs.exe");
-						pathTempfile = Path.Combine(Directory.GetCurrentDirectory(),"tempfile.ff8");
-						pathTempfile2 = Path.Combine(Directory.GetCurrentDirectory(),"tempfle2.ff8");
-							
-						//Compress
-						ProcessStartInfo startLZS = new ProcessStartInfo(pathLZS);
-						startLZS.WindowStyle = ProcessWindowStyle.Hidden;
-							
-						startLZS.Arguments = "-c \""+pathTempfile+"\" \""+pathTempfile2+"\"";
-						var process = Process.Start(startLZS);
-						process.WaitForExit();
-						//
-						
-						path = Path.Combine(Directory.GetCurrentDirectory(),"tempfle2.ff8");
-						FileIO.load_file(ref savebuffer, ref path, null);
-						FileIO.save_file(savebuffer, chocorpgfilter);
-						//Remove tempfl2.ff8 after we saved
-						if (File.Exists(path)) File.Delete(path);
-					}
-					else if (compressor == 1) //qt-lzs.exe
-					{
-						//Write edited data to temp file we will be compressing
-						FileIO.write_file(save.Data, Path.Combine(Directory.GetCurrentDirectory(),"tempfile.ff8"));
-						
-						pathLZS = "\"" + Path.Combine(Directory.GetCurrentDirectory(), "qt-lzs\\lzs.exe") + "\"";
-						string pathTempSave = Path.Combine(Directory.GetCurrentDirectory(),"tempfile.ff8");
-							
-						//Compress
-						ProcessStartInfo startLZS = new ProcessStartInfo(pathLZS);
-						startLZS.WindowStyle = ProcessWindowStyle.Hidden;
-							
-						startLZS.Arguments = "\""+pathTempSave+"\" "+"\""+Directory.GetCurrentDirectory()+"\"";
-						var process = Process.Start(startLZS);
-						process.WaitForExit();
-						//
-						
-						//Remove temp uncompressed data
-						if (File.Exists(pathTempSave)) File.Delete(pathTempSave);
-						
-						path = Path.Combine(Directory.GetCurrentDirectory(),"tempfile.ff8.lzs");
-						FileIO.load_file(ref savebuffer, ref path, null);
-						FileIO.save_file(savebuffer, chocorpgfilter);
-						
-						//Remove .lzs after we saved
-						if (File.Exists(path)) File.Delete(path);
-					}
-				}
-				else
-					FileIO.save_file(savebuffer, chocorpgfilter);
-			}
-		}
-		void SavegamenameTextChanged(object sender, EventArgs e)
-		{
+        //True if save is being edited via plugin interface
+        public bool pluginEditing = false;
+        public bool saveAndClose = false;
 
-		}
-		void AboutClick(object sender, EventArgs e)
-		{
-			MessageBox.Show("Chocobo World Editor 0.2c by suloku"
-			                + "\n\nThanks to:\n- Ortew Lant for his awesome Chocobo World guide and help with some offsets back in 2013.\n- Ficedula for his LZS (de)compressor."
-			               );
-		}
-		void load_data()
-		{
-			if (save.HP_max >99)
-				hp_max.Value = 99;
-			else if (save.HP_max <6)
-				hp_max.Value = 6;
-			else
-				hp_max.Value = save.HP_max;
-			
-			if (save.HP_cur >99)
-				hp_curr.Value = 99;
-			else
-				hp_curr.Value = save.HP_cur;
-			
-			level.Value = save.level;
-			rank.Value = save.rank;
-			powerups.Value = save.Powerups;
-			
-			//weapon_hi.Value = save.weapon_first;
-			//weapon_lo.Value = save.weapon_last;
-			weapon.Value = save.weapon;
-			ID.Value = save.ID;
-			
-			ff8_id.Text = save.FF8ID.ToString("X");
-			
-			item_a.Value = save.ITEM_A;
-			item_b.Value = save.ITEM_B;
-			item_c.Value = save.ITEM_C;
-			item_d.Value = save.ITEM_D;
-			
-			//Flags
-			flag0.Checked = save.Eventflag0;
-			flag1.Checked = save.Away;
-			mogu_found.Checked = save.MoguFound;
-			mogu_have.Checked = save.MoguHave;
-			mogu_standby.Checked = save.MoguStandby;
-			demon_defeat.Checked = save.DemonDefeated;
-			lvlevent.Checked = save.LvlEvent;
-			event_wait.Checked = save.EventWait;
-		}
-		void save_data()
-		{
-			save.HP_max = (int)hp_max.Value;
-			save.HP_cur = (int)hp_curr.Value;
-			
-			save.level = (int)level.Value;
-		 	save.rank = (int)rank.Value;
-			save.Powerups = (int)powerups.Value;
-			
-			save.weapon = (int)weapon.Value;
-			save.ID = (int)ID.Value;
-			
-			//ff8_id.Text = save.FF8ID.ToString("X");
-			
-			save.ITEM_A = (int)item_a.Value;
-			save.ITEM_B = (int)item_b.Value;
-			save.ITEM_C = (int)item_c.Value;
-			save.ITEM_D = (int)item_d.Value;
-			
-			//Flags
-			//save.Eventflag0 = flag0.Checked;
-			//save.Away = flag1.Checked;
-			save.MoguFound = mogu_found.Checked;
-			save.MoguHave = mogu_have.Checked;
-			save.MoguStandby = mogu_standby.Checked;
-			save.DemonDefeated = demon_defeat.Checked;
-			save.LvlEvent = lvlevent.Checked;
-			save.EventWait = event_wait.Checked;
-		}
-		void MainFormLoad(object sender, EventArgs e)
-		{
-	
-		}
-		void Hp_currValueChanged(object sender, EventArgs e)
-		{
-			if (hp_curr.Value > hp_max.Value) hp_curr.Value = hp_max.Value;
-		}
-		void Ff8id_setClick(object sender, EventArgs e)
-		{
-			string path = null;
-			int filesize = FileIO.load_file(ref ff8buffer, ref path, mcsfilter);
-			versiontext.Text = "";
+        void MainScreenDragEnter(object sender, DragEventArgs e)
+        {
+            e.Effect = DragDropEffects.All;
+        }
+        void MainScreenDragDrop(object sender, DragEventArgs e)
+        {
+            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop, false);
+            load_savegame(files[0]);
+        }
+        void Loadsave_butClick(object sender, EventArgs e)
+        {
+            load_savegame(null);
+        }
+        public static int compressor = 0;//0 lzs.exe, 1 qt-lzs.exe and unlzs.exe
+        public static string pathTempfile = null;
+        public static bool isCompressed = true;
+        public void load_savegame(string filepath)
+        {
 
-			if( filesize == 8320 )
-			{
-				ff8ID = BitConverter.ToUInt32(ff8buffer, 0x1588);
-				save.FF8ID = ff8ID;
-				
-				ff8_id.Text = save.FF8ID.ToString("X");
-				
-			}else{
-				MessageBox.Show("Invalid file.");
-			}
-		}
-		void About_rankClick(object sender, EventArgs e)
-		{
-			MessageBox.Show(
-				"Rank---Max.----Max.-------Probability-of-item----#ID----ID"+
-				"\n--##----HP---Weapon------A----B-----C-----D-----------Requirement"+
-				"\n----------------------------------------------------------------------"+
-				"\n--00-----41-----9999------25%--25%--25%--25%-----1---211"+
-				"\n--01-----37-----9998-------5%--35%--30%--30%-----3---000,0008,777"+
-				"\n--02-----35-----9898-------4%--10%--46%--40%-----8---All-digits-the-same"+
-				"\n--03-----34-----9888-------3%--10%--37%--50%-----9---Ending-in-00"+
-				"\n--04-----33-----9698-------2%--10%--28%--60%-----9---Ending-in-77"+
-				"\n--05-----32-----9698-------1%---5%--25%--70%----90---Ending-in-7"+
-				"\n--06-----31-----9698?------0%---5%--15%--80%---880---Any-other-number"+
-				"\n\n In PC the probability is always A-3% B-10% C-37% D-50%"+
-				"\n\nMax. HP is automatically set when you advance a level (so even if it is set to 99, after level up it will be set depending on rank)"
-			);
-		}
-		void About_flagsClick(object sender, EventArgs e)
-		{
-			MessageBox.Show("About Level event happened:\n"
-				+"Events happen at level 20, 50 (Boko PowerUp), 75, 100. I guess it is unset after every level up. Needs to be re-set to be able to battle the Demon King at level 100 (and Demon King defeated flag needs to be unset)"
-				+"\n\nAbout Mogu found flag:"
-				+"\nIn normal gameplay you can only encounter Mogu after reaching level 10. If you set this before level 10 you can encounter mogu even at level 1."
-			);
-		}
-		void Hp_maxValueChanged(object sender, EventArgs e)
-		{
-	
-		}
- 
-		static void OnProcessExit (object sender, EventArgs e)
-	    {
-			//Remove tempfile.ff8 / *.dec when closing
-			if (File.Exists(pathTempfile)) File.Delete(pathTempfile);
-			if (File.Exists(Path.Combine(Directory.GetCurrentDirectory(),"tempfile.ff8"))) File.Delete(Path.Combine(Directory.GetCurrentDirectory(),"tempfile.ff8"));
-	    }
-	}
+            string path = filepath;
+            int filesize = 0;
+
+            if (pluginEditing)
+                filesize = savebuffer.Count();
+            else
+                filesize = FileIO.load_file(ref savebuffer, ref path, loadfilter);
+
+            versiontext.Text = "";
+
+            if (filesize > 0)
+            {
+                savegamename.Text = path;
+                save = new Choco(savebuffer, filesize);
+
+                if (filesize == Choco.PSXSIZE) //PSX
+                {
+                    versiontext.Text = "PSX";
+                    save_but.Enabled = true;
+                    ff8id_set.Enabled = true;
+
+                    load_data();
+                }
+                else //PC
+                {
+                    //Decompress if needed
+                    if (save.isLzs == true)
+                    {
+                        isCompressed = true;
+                        versiontext.Text = "PC";
+                        string pathLZS;
+
+                        if (compressor == 0)//use lzs.exe
+                        {
+
+                            pathLZS = Path.Combine(Directory.GetCurrentDirectory(), "lzs.exe");
+                            pathTempfile = Path.Combine(Directory.GetCurrentDirectory(), "tempfile.ff8");
+
+                            //Cleanup so we don't load a previous savefile if some error occurs
+                            if (File.Exists(pathTempfile)) File.Delete(pathTempfile);
+
+                            //Decompress
+                            ProcessStartInfo startLZS = new ProcessStartInfo(pathLZS);
+                            startLZS.WindowStyle = ProcessWindowStyle.Hidden;
+
+                            startLZS.Arguments = "-d \"" + path + "\" \"" + pathTempfile + "\"";
+                            var process = Process.Start(startLZS);
+                            process.WaitForExit();
+                            //
+                            path = Path.Combine(Directory.GetCurrentDirectory(), "tempfile.ff8");
+                        }
+                        else if (compressor == 1)//Use qt-lzs
+                        {
+                            //If we are loading a new compressed file, delete previous decompressed one
+                            if (pathTempfile != null)
+                                if (File.Exists(pathTempfile)) File.Delete(pathTempfile);
+
+                            pathLZS = "\"" + Path.Combine(Directory.GetCurrentDirectory(), "qt-lzs\\unlzs.exe") + "\"";
+                            pathTempfile = Path.Combine(Path.Combine(Directory.GetCurrentDirectory(), "qt-lzs"), Path.GetFileName(path) + ".dec");
+
+                            //Cleanup so we don't load a previous decomp savefile if some error occurs
+                            if (File.Exists(pathTempfile)) File.Delete(pathTempfile);
+
+                            //Decompress
+                            ProcessStartInfo startLZS = new ProcessStartInfo(pathLZS);
+                            startLZS.WindowStyle = ProcessWindowStyle.Hidden;
+
+                            startLZS.Arguments = "\"" + path + "\" " + "\"" + Path.Combine(Directory.GetCurrentDirectory(), "qt-lzs") + "\"";
+                            var process = Process.Start(startLZS);
+                            process.WaitForExit();
+                            //
+
+                            path = pathTempfile;
+                        }
+                    }
+                    else
+                    {
+                        isCompressed = false;
+                        versiontext.Text = "PC (uncompressed)";
+                    }
+
+                    FileIO.load_file(ref savebuffer, ref path, null);
+
+                    save = new Choco(savebuffer);
+                    save_but.Enabled = true;
+                    load_data();
+                    //Remove *.dec file
+                    if (File.Exists(path)) File.Delete(path);
+                }
+
+            }
+            else
+            {
+                MessageBox.Show("Invalid file.");
+                savegamename.Text = "";
+                save_but.Enabled = false;
+                ff8id_set.Enabled = false;
+            }
+        }
+        void Save_butClick(object sender, EventArgs e)
+        {
+            save_data();
+
+            if (pluginEditing)
+            {
+                saveAndClose = true;
+                this.Close();
+                return;
+            }
+
+            if (save.Data.Length == Choco.PSXSIZE)
+            {
+                FileIO.save_file(save.Data, mcsfilter);
+            }
+            else
+            {
+                string pathLZS;
+                string pathTempfile2;
+                string path;
+                if (isCompressed == true) //Recompress
+                {
+                    if (compressor == 0) //lzs.exe
+                    {
+                        //Write edited data to temp file we will be compressing
+                        FileIO.write_file(save.Data, Path.Combine(Directory.GetCurrentDirectory(), "tempfile.ff8"));
+
+                        pathLZS = Path.Combine(Directory.GetCurrentDirectory(), "lzs.exe");
+                        pathTempfile = Path.Combine(Directory.GetCurrentDirectory(), "tempfile.ff8");
+                        pathTempfile2 = Path.Combine(Directory.GetCurrentDirectory(), "tempfle2.ff8");
+
+                        //Compress
+                        ProcessStartInfo startLZS = new ProcessStartInfo(pathLZS);
+                        startLZS.WindowStyle = ProcessWindowStyle.Hidden;
+
+                        startLZS.Arguments = "-c \"" + pathTempfile + "\" \"" + pathTempfile2 + "\"";
+                        var process = Process.Start(startLZS);
+                        process.WaitForExit();
+                        //
+
+                        path = Path.Combine(Directory.GetCurrentDirectory(), "tempfle2.ff8");
+                        FileIO.load_file(ref savebuffer, ref path, null);
+                        FileIO.save_file(savebuffer, chocorpgfilter);
+                        //Remove tempfl2.ff8 after we saved
+                        if (File.Exists(path)) File.Delete(path);
+                    }
+                    else if (compressor == 1) //qt-lzs.exe
+                    {
+                        //Write edited data to temp file we will be compressing
+                        FileIO.write_file(save.Data, Path.Combine(Directory.GetCurrentDirectory(), "tempfile.ff8"));
+
+                        pathLZS = "\"" + Path.Combine(Directory.GetCurrentDirectory(), "qt-lzs\\lzs.exe") + "\"";
+                        string pathTempSave = Path.Combine(Directory.GetCurrentDirectory(), "tempfile.ff8");
+
+                        //Compress
+                        ProcessStartInfo startLZS = new ProcessStartInfo(pathLZS);
+                        startLZS.WindowStyle = ProcessWindowStyle.Hidden;
+
+                        startLZS.Arguments = "\"" + pathTempSave + "\" " + "\"" + Directory.GetCurrentDirectory() + "\"";
+                        var process = Process.Start(startLZS);
+                        process.WaitForExit();
+                        //
+
+                        //Remove temp uncompressed data
+                        if (File.Exists(pathTempSave)) File.Delete(pathTempSave);
+
+                        path = Path.Combine(Directory.GetCurrentDirectory(), "tempfile.ff8.lzs");
+                        FileIO.load_file(ref savebuffer, ref path, null);
+                        FileIO.save_file(savebuffer, chocorpgfilter);
+
+                        //Remove .lzs after we saved
+                        if (File.Exists(path)) File.Delete(path);
+                    }
+                }
+                else
+                    FileIO.save_file(savebuffer, chocorpgfilter);
+            }
+        }
+        void SavegamenameTextChanged(object sender, EventArgs e)
+        {
+
+        }
+        public void AboutClick(object sender, EventArgs e)
+        {
+            MessageBox.Show("Chocobo World Editor 0.2c by suloku"
+                            + "\n\nThanks to:\n- Ortew Lant for his awesome Chocobo World guide and help with some offsets back in 2013.\n- Ficedula for his LZS (de)compressor."
+                           );
+        }
+        void load_data()
+        {
+            if (save.HP_max > 99)
+                hp_max.Value = 99;
+            else if (save.HP_max < 6)
+                hp_max.Value = 6;
+            else
+                hp_max.Value = save.HP_max;
+
+            if (save.HP_cur > 99)
+                hp_curr.Value = 99;
+            else
+                hp_curr.Value = save.HP_cur;
+
+            level.Value = save.level;
+            rank.Value = save.rank;
+            powerups.Value = save.Powerups;
+
+            //weapon_hi.Value = save.weapon_first;
+            //weapon_lo.Value = save.weapon_last;
+            weapon.Value = save.weapon;
+            ID.Value = save.ID;
+
+            ff8_id.Text = save.FF8ID.ToString("X");
+
+            item_a.Value = save.ITEM_A;
+            item_b.Value = save.ITEM_B;
+            item_c.Value = save.ITEM_C;
+            item_d.Value = save.ITEM_D;
+
+            //Flags
+            flag0.Checked = save.Eventflag0;
+            flag1.Checked = save.Away;
+            mogu_found.Checked = save.MoguFound;
+            mogu_have.Checked = save.MoguHave;
+            mogu_standby.Checked = save.MoguStandby;
+            demon_defeat.Checked = save.DemonDefeated;
+            lvlevent.Checked = save.LvlEvent;
+            event_wait.Checked = save.EventWait;
+        }
+        void save_data()
+        {
+            save.HP_max = (int)hp_max.Value;
+            save.HP_cur = (int)hp_curr.Value;
+
+            save.level = (int)level.Value;
+            save.rank = (int)rank.Value;
+            save.Powerups = (int)powerups.Value;
+
+            save.weapon = (int)weapon.Value;
+            save.ID = (int)ID.Value;
+
+            //ff8_id.Text = save.FF8ID.ToString("X");
+
+            save.ITEM_A = (int)item_a.Value;
+            save.ITEM_B = (int)item_b.Value;
+            save.ITEM_C = (int)item_c.Value;
+            save.ITEM_D = (int)item_d.Value;
+
+            //Flags
+            //save.Eventflag0 = flag0.Checked;
+            //save.Away = flag1.Checked;
+            save.MoguFound = mogu_found.Checked;
+            save.MoguHave = mogu_have.Checked;
+            save.MoguStandby = mogu_standby.Checked;
+            save.DemonDefeated = demon_defeat.Checked;
+            save.LvlEvent = lvlevent.Checked;
+            save.EventWait = event_wait.Checked;
+        }
+        void MainFormLoad(object sender, EventArgs e)
+        {
+            if (pluginEditing)
+            {
+                loadsave_but.Enabled = false;
+                savegamename.Enabled = false;
+                save_but.Text = "Save and close";
+            }
+        }
+        void Hp_currValueChanged(object sender, EventArgs e)
+        {
+            if (hp_curr.Value > hp_max.Value) hp_curr.Value = hp_max.Value;
+        }
+        void Ff8id_setClick(object sender, EventArgs e)
+        {
+            string path = null;
+            int filesize = FileIO.load_file(ref ff8buffer, ref path, mcsfilter);
+            versiontext.Text = "";
+
+            if (filesize == 8320)
+            {
+                ff8ID = BitConverter.ToUInt32(ff8buffer, 0x1588);
+                save.FF8ID = ff8ID;
+
+                ff8_id.Text = save.FF8ID.ToString("X");
+
+            }
+            else
+            {
+                MessageBox.Show("Invalid file.");
+            }
+        }
+        void About_rankClick(object sender, EventArgs e)
+        {
+            MessageBox.Show(
+                "Rank---Max.----Max.-------Probability-of-item----#ID----ID" +
+                "\n--##----HP---Weapon------A----B-----C-----D-----------Requirement" +
+                "\n----------------------------------------------------------------------" +
+                "\n--00-----41-----9999------25%--25%--25%--25%-----1---211" +
+                "\n--01-----37-----9998-------5%--35%--30%--30%-----3---000,0008,777" +
+                "\n--02-----35-----9898-------4%--10%--46%--40%-----8---All-digits-the-same" +
+                "\n--03-----34-----9888-------3%--10%--37%--50%-----9---Ending-in-00" +
+                "\n--04-----33-----9698-------2%--10%--28%--60%-----9---Ending-in-77" +
+                "\n--05-----32-----9698-------1%---5%--25%--70%----90---Ending-in-7" +
+                "\n--06-----31-----9698?------0%---5%--15%--80%---880---Any-other-number" +
+                "\n\n In PC the probability is always A-3% B-10% C-37% D-50%" +
+                "\n\nMax. HP is automatically set when you advance a level (so even if it is set to 99, after level up it will be set depending on rank)"
+            );
+        }
+        void About_flagsClick(object sender, EventArgs e)
+        {
+            MessageBox.Show("About Level event happened:\n"
+                + "Events happen at level 20, 50 (Boko PowerUp), 75, 100. I guess it is unset after every level up. Needs to be re-set to be able to battle the Demon King at level 100 (and Demon King defeated flag needs to be unset)"
+                + "\n\nAbout Mogu found flag:"
+                + "\nIn normal gameplay you can only encounter Mogu after reaching level 10. If you set this before level 10 you can encounter mogu even at level 1."
+            );
+        }
+        void Hp_maxValueChanged(object sender, EventArgs e)
+        {
+
+        }
+
+        static void OnProcessExit(object sender, EventArgs e)
+        {
+            //Remove tempfile.ff8 / *.dec when closing
+            if (File.Exists(pathTempfile)) File.Delete(pathTempfile);
+            if (File.Exists(Path.Combine(Directory.GetCurrentDirectory(), "tempfile.ff8"))) File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "tempfile.ff8"));
+        }
+    }
 }

--- a/ChocoEdit/Plugin.cs
+++ b/ChocoEdit/Plugin.cs
@@ -1,0 +1,84 @@
+﻿using ChocoEdit;
+using System.Windows.Forms;
+
+namespace rexPluginSystem
+{
+    //All plugins should incorporate this interface in order to comunicate with MemcardRex 1.6+.
+    public interface rexPluginInterfaceV2
+    {
+        string getPluginName();
+        string getPluginAuthor();
+        string getPluginSupportedGames();
+        string[] getSupportedProductCodes();
+        byte[] editSaveData(byte[] gameSaveData, string saveProductCode);
+        void showAboutDialog();
+        void showConfigDialog();
+    }
+
+    public class rexPlugin : rexPluginInterfaceV2
+    {
+        private const string pluginName = "ChocoEdit";
+        private const string pluginVersion = "0.2c";
+        private const string pluginAuthor = "suloku";
+        private const string pluginSupportedGames = "ChocoboWorld (PocketStation)";
+
+        //Return Plugin's name (name + plugin version is recommended)
+        public string getPluginName()
+        {
+            return pluginName + " " + pluginVersion;
+        }
+
+        //Return Author's name.
+        public string getPluginAuthor()
+        {
+            return pluginAuthor;
+        }
+
+        //Return a list of games supported by the plugin
+        public string getPluginSupportedGames()
+        {
+            return pluginSupportedGames;
+        }
+
+        //Return a string array of product codes compatible with this plugin.
+        //In order to make a product-code-independent-plugin one member should be "*.*".
+        public string[] getSupportedProductCodes()
+        {
+            //All versions of Spyro the Dragon are supported
+            return new string[] { "SLUSP00892" };
+        }
+
+        //A data to process. Edited save data should be returned.
+        //Array size depends on the number of slots that specific save takes (Save header (128 bytes) + Number of slots * 8192 bytes).
+        public byte[] editSaveData(byte[] gameSaveData, string saveProductCode)
+        {
+            if(gameSaveData.Length != Choco.PSXSIZE)
+            {
+                MessageBox.Show("This FF8 save does not contain Chocobo World", pluginName + " " + pluginVersion);
+                return null;
+            }
+
+            MainForm mainForm = new MainForm(true);
+
+            //Save data in mcs form, native to both MemcardRex plugins and ChocoEdit
+            mainForm.savebuffer = gameSaveData;
+            mainForm.load_savegame("MemcardRex");
+
+            mainForm.ShowDialog();
+
+            if (mainForm.saveAndClose) return mainForm.savebuffer;
+
+            return null;
+        }
+
+        public void showAboutDialog()
+        {
+            new MainForm(true).AboutClick(this, null);
+        }
+
+        public void showConfigDialog()
+        {
+            MessageBox.Show("This plugin has no options you can configure.", pluginName + " " + pluginVersion);
+        }
+    }
+}

--- a/ChocoEdit/Program.cs
+++ b/ChocoEdit/Program.cs
@@ -24,7 +24,7 @@ namespace ChocoEdit
 		{
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
-			Application.Run(new MainForm());
+			Application.Run(new MainForm(false));
 		}
 		
 	}

--- a/ChocoEdit/app.config
+++ b/ChocoEdit/app.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
 	</startup>
 </configuration>


### PR DESCRIPTION
This pull request adds plugin interface to ChocoEdit so it can be used to edit saves directly from MemcardRex.

I came across your wonderful save editor and upon realizing that it's a C# application and it supports .mcs saves
I knew that with a bit of modification it could be adopted to serve as a plugin if exported as .dll class library.

So, few tweaks here and there and it's done.
Also, if exported as a normal .exe it will work as it already did, no functionality taken away.

![ChocoEdit](https://github.com/user-attachments/assets/c032e41f-92a3-48a1-9097-8385cf013845)
![ChocoEditPlugin](https://github.com/user-attachments/assets/5572d098-65f4-4d25-b3e2-f6de5a1c2233)
![ChocoEditEdit](https://github.com/user-attachments/assets/364ad11f-9f01-4462-9ce1-e31ec67d0ad4)
